### PR TITLE
QDB-17816 - Prioritize critical metrics

### DIFF
--- a/qdb_cloudwatch/check.py
+++ b/qdb_cloudwatch/check.py
@@ -84,6 +84,17 @@ def _check_node_writable(conn):
 
 
 def get_critical_stats(*args, **kwargs):
+    """
+    Return the minimal set of cluster health metrics required for alerting.
+
+    These metrics (i.e., `check.online` and `node.writable`) are the ones that
+    feed CloudWatch alarms and signal conditions that require immediate action.
+    By contrast, high-volume or informational metrics (cache usage, RocksDB
+    internals, etc.) are non-critical because they are (usually) not part of the
+    alerting path.
+
+    Future extensions may allow users to define their own critical metrics.
+    """
     logger.info("Getting critical stats")
     with get_qdb_conn(*args, **kwargs) as conn:
         ret = {endpoint: {"cumulative": {}} for endpoint in conn.endpoints()}

--- a/qdb_cloudwatch/check.py
+++ b/qdb_cloudwatch/check.py
@@ -23,6 +23,7 @@ def _parse_user_security_file(x):
 
 
 def get_qdb_conn(uri, cluster_public_key=None, user_security_file=None):
+    logger.info("Getting qdb connection")
     if cluster_public_key and user_security_file:
         user, private_key = _parse_user_security_file(user_security_file)
         public_key = _slurp(cluster_public_key)
@@ -36,7 +37,26 @@ def get_qdb_conn(uri, cluster_public_key=None, user_security_file=None):
         return quasardb.Cluster(uri)
 
 
+def _check_node_online(conn):
+    logger.info("Checking node online")
+    ret = {}
+
+    for endpoint in conn.endpoints():
+        ret[endpoint] = 0  # pessimistic
+        node = conn.node(endpoint)
+        entry = node.integer("$qdb.statistics.startup_epoch")  # entry always exists
+
+        try:
+            entry.get()
+            ret[endpoint] = 1
+        except quasardb.Error as e:
+            logger.error(f"[{endpoint}] Failed to read sample entry: {e}")
+
+    return ret
+
+
 def _check_node_writable(conn):
+    logger.info("Checking node writable")
     key = f"_qdb_write_check_{uuid.uuid4().hex}"  # almost zero chance of collision
     value = random.randint(-9223372036854775808, 9223372036854775807)
     ret = {}
@@ -50,29 +70,46 @@ def _check_node_writable(conn):
             entry.put(value)
             if entry.get() == value:
                 ret[endpoint] = 1
-        except quasardb.quasardb.Error as e:
+        except quasardb.Error as e:
             logger.error(f"[{endpoint}] Failed to put/get test entry '{key}': {e}")
         finally:
             try:
                 entry.remove()
-            except quasardb.quasardb.AliasNotFoundError:
+            except quasardb.AliasNotFoundError:
                 pass
-            except quasardb.quasardb.Error as e:
+            except quasardb.Error as e:
                 logger.error(f"[{endpoint}] Failed to clean up test entry '{key}': {e}")
 
     return ret
 
 
-def get_stats(*args, **kwargs):
+def get_critical_stats(*args, **kwargs):
+    logger.info("Getting critical stats")
     with get_qdb_conn(*args, **kwargs) as conn:
-        stats = qdbst.by_node(conn)
-        for endpoint, result in _check_node_writable(conn).items():
-            stats[endpoint]["cumulative"]["node.writable"] = {
-                "value": result,
+        ret = {endpoint: {"cumulative": {}} for endpoint in conn.endpoints()}
+        online_stats = _check_node_online(conn)
+        writable_stats = _check_node_writable(conn)
+
+        for endpoint in conn.endpoints():
+            ret[endpoint]["cumulative"]["check.online"] = {
+                "value": online_stats.get(endpoint, 0),
                 "type": qdbst.Type.GAUGE,
                 "unit": qdbst.Unit.NONE,
             }
-        return stats
+            ret[endpoint]["cumulative"]["node.writable"] = {
+                "value": writable_stats.get(endpoint, 0),
+                "type": qdbst.Type.GAUGE,
+                "unit": qdbst.Unit.NONE,
+            }
+
+        return ret
+
+
+def get_all_stats(*args, **kwargs):
+    logger.info("Getting all the stats")
+    with get_qdb_conn(*args, **kwargs) as conn:
+        ret = qdbst.by_node(conn)
+        return ret
 
 
 def _do_filter_metrics(metrics, fn):
@@ -103,6 +140,7 @@ def _do_filter(stats, fn):
 
 
 def filter_stats(stats, include=None, exclude=None):
+    logger.info("Filtering stats based on include/exclude filters")
     stats_ = copy.deepcopy(stats)
 
     if include is not None:

--- a/qdb_cloudwatch/cloudwatch.py
+++ b/qdb_cloudwatch/cloudwatch.py
@@ -18,6 +18,7 @@ _stat_unit_to_cloudwatch_unit = {
 
 
 def _get_client():
+    logger.info("Getting cloudwatch client")
     return boto3.client("cloudwatch")
 
 
@@ -84,6 +85,7 @@ def push_stats(stats, namespace):
         stats_[i : i + metrics_per_req] for i in range(0, len(stats_), metrics_per_req)
     ]
 
+    logger.info(f"Pushing {len(stats_)} metrics")
     for metric in metrics:
         _ = client.put_metric_data(Namespace=namespace, MetricData=metric)
 

--- a/qdb_cloudwatch/driver.py
+++ b/qdb_cloudwatch/driver.py
@@ -86,7 +86,7 @@ def main():
 
     args = get_args()
 
-    # Send first critical stats, getting all stats is expensive when cluster is busy.
+    # Send critical stats first, as getting all stats is expensive when cluster is busy.
     critical_stats = get_critical_stats(
         args.cluster_uri,
         cluster_public_key=args.cluster_public_key,

--- a/qdb_cloudwatch/driver.py
+++ b/qdb_cloudwatch/driver.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import sys
 
-from .check import filter_stats, get_stats
+from .check import filter_stats, get_all_stats, get_critical_stats
 from .cloudwatch import push_stats
 
 logger = logging.getLogger(__name__)
@@ -85,7 +85,16 @@ def main():
     logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 
     args = get_args()
-    stats = get_stats(
+
+    # Send first critical stats, getting all stats is expensive when cluster is busy.
+    critical_stats = get_critical_stats(
+        args.cluster_uri,
+        cluster_public_key=args.cluster_public_key,
+        user_security_file=args.user_security_file,
+    )
+    push_stats(critical_stats, args.namespace)
+
+    stats = get_all_stats(
         args.cluster_uri,
         cluster_public_key=args.cluster_public_key,
         user_security_file=args.user_security_file,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pprint
 import pytest
 import quasardb
 
-from qdb_cloudwatch.check import get_stats
+from qdb_cloudwatch.check import get_all_stats
 
 pp = pprint.PrettyPrinter()
 
@@ -85,7 +85,7 @@ def qdbd_direct_connection(request):
 
 @pytest.fixture(scope="module")
 def stats(qdbd_settings):
-    return get_stats(
+    return get_all_stats(
         qdbd_settings.get("uri"),
         cluster_public_key=qdbd_settings.get("security").get("cluster_public_key_file"),
         user_security_file=qdbd_settings.get("security").get("user_private_key_file"),

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,10 +1,10 @@
 import pytest
 
-from qdb_cloudwatch.check import get_stats
+from qdb_cloudwatch.check import get_all_stats
 
 
 def test_get_stats(qdbd_settings):
-    stats = get_stats(
+    stats = get_all_stats(
         qdbd_settings.get("uri"),
         cluster_public_key=qdbd_settings.get("security").get("cluster_public_key_file"),
         user_security_file=qdbd_settings.get("security").get("user_private_key_file"),


### PR DESCRIPTION
When a cluster becomes heavily loaded, the exporter frequently times out while attempting to retrieve the complete set of metrics. This results in essential health signals (such as online and writable) being skipped when timeouts occur.

This change prioritizes the critical metrics, avoiding false alerts and missed alarms.